### PR TITLE
pytest-randomly 3.16.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,16 @@
 {% set name = "pytest-randomly" %}
-{% set version = "3.15.0" %}
-{% set name_url = name.split('-')[0]+"_"+name.split('-')[1] %}
-
+{% set version = "3.16.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name_url }}/{{ name_url }}-{{ version }}.tar.gz
-  sha256: b908529648667ba5e54723088edd6f82252f540cc340d748d1fa985539687047
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26
 
 build:
-  skip: True  # [py<38]
+  skip: true  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -24,8 +22,8 @@ requirements:
     - setuptools
   run:
     - python
-    - importlib-metadata >=3.6.0 # [py<310]
-    - pytest 
+    - importlib-metadata >=3.6.0  # [py<310]
+    - pytest
 
 test:
   imports:
@@ -42,11 +40,11 @@ about:
   license_file: LICENSE
   license_family: MIT
   description: |
-   Pytest plugin to randomly order tests and control random.seed. By resetting the random seed to a repeatable number
-   for each test, tests can create data based on random numbers and yet remain repeatable, for example factory boy's
-   fuzzy values. This is good for ensuring that tests specify the data they need and that the tested system is not
-   affected by any data that is filled in randomly due to not being specified. Pytest will automatically find the
-   plugin and use it when you run pytest.
+    Pytest plugin to randomly order tests and control random.seed. By resetting the random seed to a repeatable number
+    for each test, tests can create data based on random numbers and yet remain repeatable, for example factory boy's
+    fuzzy values. This is good for ensuring that tests specify the data they need and that the tested system is not
+    affected by any data that is filled in randomly due to not being specified. Pytest will automatically find the
+    plugin and use it when you run pytest.
   doc_url: https://github.com/pytest-dev/pytest-randomly
   dev_url: https://github.com/pytest-dev/pytest-randomly
 


### PR DESCRIPTION
pytest-randomly 3.16.0 

**Destination channel:** Defaults

### Links

- [PKG-8239]
- dev_url:        https://github.com/pytest-dev/pytest-randomly/tree/3.16.0
- conda_forge:    https://github.com/conda-forge/pytest-randomly-feedstock
- pypi:           https://pypi.org/project/pytest-randomly/3.16.0
- pypi inspector: https://inspector.pypi.io/project/pytest-randomly/3.16.0

### Explanation of changes:

- new version number
- Fixes compatibility with CRM and the recipe-bumper
     - source url line
- used CRM to bump recipe


[PKG-8239]: https://anaconda.atlassian.net/browse/PKG-8239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ